### PR TITLE
Source/fix: Set popup monitor to default

### DIFF
--- a/watcher.js
+++ b/watcher.js
@@ -85,7 +85,7 @@ class ActionWatcher {
           this._timeoutId = 0;
         }
         this._watches.forEach((watch) => watch.remove());
-        this._watches = null;
+        this._watches = [];
       }.bind(this)
     );
   }


### PR DESCRIPTION
`this._watches` was erroneously set to null
instead of being reinitialized to empty array.