### PR TITLE
Source/fix: Crash report when viewer is relaunched

### DIFF
--- a/dialog.js
+++ b/dialog.js
@@ -38,14 +38,14 @@ var UIDialog = GObject.registerClass(
         'anchor',
         'anchor',
         'anchor',
-        GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+        GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
         St.Widget.$gtype
       ),
       overlay: GObject.ParamSpec.object(
         'overlay',
         'overlay',
         'overlay',
-        GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT_ONLY,
+        GObject.ParamFlags.READWRITE | GObject.ParamFlags.CONSTRUCT,
         St.Widget.$gtype
       )
     }

--- a/dock/appDisplay.js
+++ b/dock/appDisplay.js
@@ -189,6 +189,7 @@ var AppIcon = GObject.registerClass(
       this.set_child(this._iconContainer);
 
       this._setUpApp(app, iconParams);
+      this.connect('destroy', this._onDestroy.bind(this));
     }
 
     _createIcon(iconSize) {
@@ -197,7 +198,7 @@ var AppIcon = GObject.registerClass(
 
     _replaceApp(app) {
       const iconParams = {};
-      this._iconContainer.remove_child(this.icon);
+      this._iconContainer.destroy_all_children();
       this._setUpApp(app, this._iconParams);
     }
 
@@ -209,6 +210,13 @@ var AppIcon = GObject.registerClass(
       this.icon = new IconGrid.BaseIcon(app.get_name(), iconParams);
       this._iconContainer.add_child(this.icon);
       this.label_actor = this.icon.label;
+    }
+
+    _onDestroy() {
+      lg('[AppIcon::_onDestroy]');
+      this.app.destroy();
+      this._iconParams = null;
+      this.app = null;
     }
 
     vfunc_leave_event(event) {

--- a/dock/dash_base.js
+++ b/dock/dash_base.js
@@ -78,7 +78,7 @@ var DashItemContainer = GObject.registerClass(
       this.connect('notify::scale-y', () => this.queue_relayout());
 
       this.connect('destroy', () => {
-        this.child = null;
+        this.removeChild();
         Main.layoutManager.removeChrome(this.label);
         this.label?.destroy();
       });
@@ -157,7 +157,13 @@ var DashItemContainer = GObject.registerClass(
 
       this.child = actor;
       this.child.y_expand = false;
-      this.add_actor(this.child);
+      this.add_child(this.child);
+    }
+
+    removeChild() {
+      this.child.destroy_all_children();
+      this.destroy_all_children();
+      this.child = null;
     }
 
     show(animate) {
@@ -227,12 +233,6 @@ var Dash = GObject.registerClass(
       });
     }
 
-    _appIdListToHash(apps) {
-      let ids = {};
-      for (let i = 0; i < apps.length; i++) ids[apps[i].get_id()] = apps[i];
-      return ids;
-    }
-
     _hookUpLabel(item, appIcon) {
       item.child.connect('notify::hover', () => {
         this._syncLabel(item, appIcon);
@@ -242,15 +242,6 @@ var Dash = GObject.registerClass(
         this._labelShowing = false;
         item.hideLabel();
       });
-
-      Main.overview.connectObject(
-        'hiding',
-        () => {
-          this._labelShowing = false;
-          item.hideLabel();
-        },
-        item.child
-      );
 
       if (appIcon) {
         appIcon.connect('sync-tooltip', () => {

--- a/dock/docking.js
+++ b/dock/docking.js
@@ -149,7 +149,7 @@ var DockedDash = GObject.registerClass(
         'docker',
         'docker',
         'docker',
-        GObject.ParamFlags.READWRITE | GObject.ParamSpec.CONSTRUCT_ONLY,
+        GObject.ParamFlags.READWRITE | GObject.ParamSpec.CONSTRUCT,
         UIImageRenderer.$gtype
       )
     },
@@ -176,9 +176,6 @@ var DockedDash = GObject.registerClass(
 
       // initialize dock state
       this._dockState = State.HIDDEN;
-    }
-
-    mount() {
       // Create a new dash object
       this.dash = new DockDash.DockDash(this);
       this.dash.connect('notify::mapped', () => this.dash._queueRedisplay());

--- a/overlay.js
+++ b/overlay.js
@@ -85,7 +85,7 @@ var UIOverlay = GObject.registerClass(
 
       this._monitorBins = [];
       this._rebuildMonitorBins();
-      this.monitorChangeID = Main.layoutManager.connect(
+      this._monitorChangeID = Main.layoutManager.connect(
         'monitors-changed',
         () => {
           this._close();
@@ -104,7 +104,7 @@ var UIOverlay = GObject.registerClass(
 
     _onDestroy() {
       Main.sessionMode.disconnect(this.sessionUpdateID);
-      Main.layoutManager.disconnect(this.monitorChangeID);
+      Main.layoutManager.disconnect(this._monitorChangeID);
       if (this._timeoutId) {
         GLib.Source.remove(this._timeoutId);
         this._timeoutId = null;

--- a/screenshot.js
+++ b/screenshot.js
@@ -918,8 +918,6 @@ var UIShutter = GObject.registerClass(
         reactive: true
       });
 
-      this._settings = inflateSettings();
-
       // The full-screen screenshot has a separate container so that we can
       // show it without the screenshot UI fade-in for a nicer animation.
       this._stageScreenshotContainer = new St.Widget({ visible: false });

--- a/utils.js
+++ b/utils.js
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
-const { Gio, GLib, Clutter } = imports.gi;
+const { Gio, GLib } = imports.gi;
 
 const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();


### PR DESCRIPTION
Applications were previously managed by two different widgets which requires detach from the two widgets upon destruction. When the viewer is destroyed, one of the widget destroys its child while the other
is left hanging. Then the app is relaunched, the
hanging app is still being held. This causes crash when the app is clicked. The fix to this is to remove one of the reference being managed by one of the
widgets.

In `_bindConstraints`, we use a tag `_bindDir` to
prevent binding to the same side twice. Without this we introduce errors in the layout of the widgets.

Cleanup of all used widget have been improved.