### PR TITLE
Source/Fix: Take screenshot button stopped working

### DIFF
--- a/screenshot.js
+++ b/screenshot.js
@@ -1134,7 +1134,6 @@ var UIShutter = GObject.registerClass(
         'clicked',
         this._onCaptureButtonClicked.bind(this)
       );
-      this._bottomRowContainer.add_child(this._captureButton);
 
       this._ocrActionBox = new St.Widget({
         x_align: Clutter.ActorAlign.FILL,
@@ -1145,6 +1144,7 @@ var UIShutter = GObject.registerClass(
         })
       });
       this._bottomRowContainer.add_child(this._ocrActionBox);
+      this._bottomRowContainer.add_child(this._captureButton);
 
       this._expandButton = new IconLabelButton(
         `${getIconsLocation().get_path()}/screenshot-ui-expand-symbolic.png`,

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -94,19 +94,6 @@
   background-color: white;
 }
 
-.pixzzle-ui-capture-button:cast .pixzzle-ui-capture-button-circle {
-  background-color: #e56a54;
-}
-
-.pixzzle-ui-capture-button:cast:hover .pixzzle-ui-capture-button-circle,
-.pixzzle-ui-capture-button:cast:focus .pixzzle-ui-capture-button-circle {
-  background-color: #cd3a1f;
-}
-
-.pixzzle-ui-capture-button:cast:active .pixzzle-ui-capture-button-circle {
-  background-color: #8b2715;
-}
-
 .pixzzle-ui-expand-button {
   border-radius: 10px;
   padding: 6px 8px !important;
@@ -134,7 +121,7 @@
 .pixzzle-ui-expand-button:hover,
 .pixzzle-ui-expand-button:focus
 {
-  background-color: rgba(237, 237, 237, 0.15) !important;
+  background-color: rgba(237, 237, 237, 0.15);
 }
 
 .pixzzle-ui-ocr-action-button:checked:hover {


### PR DESCRIPTION
The addition of a new layer `ocrActionBox` to
accommodate the new `expand` button has caused
problem due to the way the order of insertion
into their parent box. This has been corrected.